### PR TITLE
fix: bash: line 18: BASH_SOURCE[0]: unbound variable

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -15,7 +15,7 @@ VERSION="${SS_VERSION:-latest}"
 CONFIG_DIR="/etc/shadowsocks-rust"
 CONFIG_FILE="${CONFIG_DIR}/config.json"
 BIN_DIR="/usr/local/bin"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(pwd)"
 
 # Help message
 usage() {


### PR DESCRIPTION
Fix #10 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment script to use the current working directory as the base path for generating and ordering ancillary files, instead of the script’s location.
  * This change affects where service files and related artifacts are created; ensure you run the script from the directory where you want these files to be written.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->